### PR TITLE
build: update tsconfig - disable use strict

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,12 +17,13 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "noImplicitUseStrict": true,
 
     /* Strict Type-Checking Options */
-    "strict": true,                            /* Enable all strict type-checking options. */
+    // "strict": true,                            /* Enable all strict type-checking options. */
     "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "strictNullChecks": true,              /* Enable strict null checks. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
remove "use strict" declaration, so ie11 won't crash with "Accessing the 'caller' property of a
function or arguments object is not allowed in strict mode"